### PR TITLE
exec creds enablement flag

### DIFF
--- a/business/mesh.go
+++ b/business/mesh.go
@@ -330,7 +330,7 @@ func (in *MeshService) findRemoteKiali(clusterName string, cluster kubernetes.Re
 	}
 
 	restConfig.Timeout = 15 * time.Second
-	restConfig.BearerToken = user.User.Token
+	kubernetes.SetUserIdentificationFromRemoteSecretUser(restConfig, &user)
 	remoteClientSet, clientSetErr := in.newRemoteClient(restConfig)
 	if clientSetErr != nil {
 		log.Errorf("Error creating client set for cluster [%s]: %v", clusterName, clientSetErr)
@@ -480,7 +480,7 @@ func (in *MeshService) resolveNetwork(clusterName string, cluster kubernetes.Rem
 	}
 
 	restConfig.Timeout = 15 * time.Second
-	restConfig.BearerToken = user.User.Token
+	kubernetes.SetUserIdentificationFromRemoteSecretUser(restConfig, &user)
 	remoteClientSet, clientSetErr := in.newRemoteClient(restConfig)
 	if clientSetErr != nil {
 		log.Errorf("Error creating client set for cluster [%s]: %v", clusterName, clientSetErr)

--- a/business/mesh_test.go
+++ b/business/mesh_test.go
@@ -179,7 +179,7 @@ func TestGetClustersResolvesRemoteClusters(t *testing.T) {
 		Users: []kubernetes.RemoteSecretUser{
 			{
 				Name: "foo",
-				User: kubernetes.RemoteSecretUserToken{
+				User: kubernetes.RemoteSecretUserAuthInfo{
 					Token: "bar",
 				},
 			},

--- a/config/config.go
+++ b/config/config.go
@@ -448,9 +448,15 @@ type CertificatesInformationIndicators struct {
 	Secrets []string `yaml:"secrets,omitempty" json:"secrets,omitempty"`
 }
 
+// Clustering defines configuration around multi-cluster functionality.
+type Clustering struct {
+	EnableExecProvider bool `yaml:"enable_exec_provider,omitempty" json:"enable_exec_provider"`
+}
+
 // KialiFeatureFlags available from the CR
 type KialiFeatureFlags struct {
 	CertificatesInformationIndicators CertificatesInformationIndicators `yaml:"certificates_information_indicators,omitempty" json:"certificatesInformationIndicators"`
+	Clustering                        Clustering                        `yaml:"clustering,omitempty" json:"clustering,omitempty"`
 	DisabledFeatures                  []string                          `yaml:"disabled_features,omitempty" json:"disabledFeatures,omitempty"`
 	IstioAnnotationAction             bool                              `yaml:"istio_annotation_action,omitempty" json:"istioAnnotationAction"`
 	IstioInjectionAction              bool                              `yaml:"istio_injection_action,omitempty" json:"istioInjectionAction"`
@@ -649,6 +655,9 @@ func NewConfig() (c *Config) {
 			CertificatesInformationIndicators: CertificatesInformationIndicators{
 				Enabled: true,
 				Secrets: []string{"cacerts", "istio-ca-secret"},
+			},
+			Clustering: Clustering{
+				EnableExecProvider: false,
 			},
 			DisabledFeatures:      []string{},
 			IstioAnnotationAction: true,

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -36,7 +36,7 @@ DEFAULT_REMOTE_CLUSTER_CONTEXT="west"
 DEFAULT_REMOTE_CLUSTER_NAME=""
 DEFAULT_REMOTE_CLUSTER_NAMESPACE="kiali-access-ns"
 DEFAULT_VIEW_ONLY="true"
-DEFAULT_EXEC_AUTH="false"
+DEFAULT_EXEC_AUTH_JSON=""
 
 : ${ALLOW_SKIP_TLS_VERIFY:=${DEFAULT_ALLOW_SKIP_TLS_VERIFY}}
 : ${CLIENT_EXE:=${DEFAULT_CLIENT_EXE}}
@@ -52,7 +52,7 @@ DEFAULT_EXEC_AUTH="false"
 : ${REMOTE_CLUSTER_NAMESPACE:=${DEFAULT_REMOTE_CLUSTER_NAMESPACE}}
 : ${REMOTE_CLUSTER_NAME:=${DEFAULT_REMOTE_CLUSTER_NAME}}
 : ${VIEW_ONLY:=${DEFAULT_VIEW_ONLY}}
-: ${EXEC_AUTH:=${DEFAULT_EXEC_AUTH}}
+: ${EXEC_AUTH_JSON:=${DEFAULT_EXEC_AUTH_JSON}}
 
 DRY_RUN_ARG="--dry-run=none"
 
@@ -246,20 +246,12 @@ create_kiali_remote_cluster_secret() {
     error "The remote cluster name [${REMOTE_CLUSTER_NAME}] does not conform to Kubernetes rules for secret key data. Use --remote-cluster-name to specify a name that matches the regex '^[-._a-zA-Z0-9]+$'"
   fi
 
-  if [ "${EXEC_AUTH}" == "true" ]; then
-    local user_auth="exec:
-          apiVersion: client.authentication.k8s.io/v1beta1
-          command: echo
-          args:
-          - |
-            {
-              \"apiVersion\": \"client.authentication.k8s.io/v1beta1\",
-              \"kind\": \"ExecCredential\",
-              \"status\": {
-                \"token\": "\"$TOKEN\""
-              }
-            }
-          interactiveMode: IfAvailable"
+  if [ "${EXEC_AUTH_JSON}" != "" ]; then
+    local user_auth=$(cat <<EOF
+env:
+$(echo ${EXEC_AUTH_JSON} | yq -P | sed "s/^/  /g")
+EOF
+)
   else
     local user_auth="token: ${TOKEN}"
   fi
@@ -289,7 +281,7 @@ stringData:
     users:
     - name: ${REMOTE_CLUSTER_NAME}
       user:
-        ${user_auth}
+$(echo "${user_auth}" | sed "s/^/        /g")
     clusters:
     - name: ${REMOTE_CLUSTER_NAME}
       cluster:
@@ -382,9 +374,8 @@ while [ $# -gt 0 ]; do
       VIEW_ONLY="$2"
       shift;shift
       ;;
-    -ea|--exec-auth)
-      [ "${2:-}" != "true" -a "${2:-}" != "false" ] && error "--exec-auth must be 'true' or 'false'"
-      EXEC_AUTH="$2"
+    -eaj|--exec-auth-json)
+      EXEC_AUTH_JSON="$2"
       shift;shift
       ;;
     -h|--help)
@@ -481,11 +472,13 @@ Valid command line arguments:
   -vo|--view-only: if 'true' then the created service account/remote secret
                    will only provide a read-only view of the remote cluster.
                    Default: "${DEFAULT_VIEW_ONLY}"
-  -ea|--exec-auth: If 'true', use the mocked exec auth for remote secret authentication.
-                   To use this option, kiali's 'auth.strategy' must be changed to 'anonymous'.
-                   (e.g. helm upgrade -n istio-system --set auth.strategy="anonymous" \\
-                         kiali-server kiali/kiali-server)
-                   Default: "${DEFAULT_EXEC_AUTH}"
+  -eaj|--exec-auth-json: If you want to use exec auth for authentication, 
+                         specify ExecConfig in clientcmd/v1 in json format
+                         To use this option, kiali's 'auth.strategy' must be 
+                         changed to 'anonymous'. 'yq' command is required.
+                         (e.g. helm upgrade -n istio-system \\
+                         --set auth.strategy="anonymous" kiali-server kiali/kiali-server)
+                         Default: "${DEFAULT_EXEC_AUTH_JSON}"
   -h|--help: this text.
 HELPMSG
       exit 1
@@ -514,7 +507,7 @@ info REMOTE_CLUSTER_CONTEXT=${REMOTE_CLUSTER_CONTEXT}
 info REMOTE_CLUSTER_NAME=${REMOTE_CLUSTER_NAME}
 info REMOTE_CLUSTER_NAMESPACE=${REMOTE_CLUSTER_NAMESPACE}
 info VIEW_ONLY=${VIEW_ONLY}
-info EXEC_AUTH=${EXEC_AUTH}
+info EXEC_AUTH_JSON=${EXEC_AUTH_JSON}
 
 #
 # Main processing - get some additional information we need and then start creating (or deleting) resources.

--- a/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+++ b/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
@@ -249,7 +249,7 @@ create_kiali_remote_cluster_secret() {
   if [ "${EXEC_AUTH_JSON}" != "" ]; then
     local user_auth=$(cat <<EOF
 env:
-$(echo ${EXEC_AUTH_JSON} | yq -P | sed "s/^/  /g")
+$(echo "${EXEC_AUTH_JSON}" | yq -P | sed "s/^/  /g")
 EOF
 )
   else
@@ -507,7 +507,7 @@ info REMOTE_CLUSTER_CONTEXT=${REMOTE_CLUSTER_CONTEXT}
 info REMOTE_CLUSTER_NAME=${REMOTE_CLUSTER_NAME}
 info REMOTE_CLUSTER_NAMESPACE=${REMOTE_CLUSTER_NAMESPACE}
 info VIEW_ONLY=${VIEW_ONLY}
-info EXEC_AUTH_JSON=${EXEC_AUTH_JSON}
+info EXEC_AUTH_JSON="${EXEC_AUTH_JSON}"
 
 #
 # Main processing - get some additional information we need and then start creating (or deleting) resources.

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -77,10 +77,34 @@ func (client *K8SClient) GetToken() string {
 	return client.token
 }
 
+func SetUserIdentificationFromRemoteSecretUser(config *rest.Config, user *RemoteSecretUser) {
+	if len(user.User.Token) > 0 {
+		config.BearerToken = user.User.Token
+	}
+	exec := user.User.Exec
+	if exec != nil {
+		config.ExecProvider = &api.ExecConfig{
+			Command:            exec.Command,
+			Args:               exec.Args,
+			Env:                exec.Env,
+			APIVersion:         exec.APIVersion,
+			InstallHint:        cleanANSIEscapeCodes(exec.InstallHint),
+			ProvideClusterInfo: exec.ProvideClusterInfo,
+			InteractiveMode:    exec.InteractiveMode,
+		}
+	}
+}
+
 // GetConfigForRemoteClusterInfo points the returned k8s client config to a remote cluster's API server.
-// The returned config will have the user's token associated with it.
+// The returned config will have the user's token and ExecProvider associated with it.
+// If both are set, the bearer token takes precedence.
 func GetConfigForRemoteClusterInfo(cluster RemoteClusterInfo) (*rest.Config, error) {
-	return GetConfigWithTokenForRemoteCluster(cluster.Cluster, cluster.User)
+	config, err := GetConfigForRemoteCluster(cluster.Cluster)
+	if err != nil {
+		return nil, err
+	}
+	SetUserIdentificationFromRemoteSecretUser(config, &cluster.User)
+	return config, nil
 }
 
 // GetConfigWithTokenForRemoteCluster points the returned k8s client config to a remote cluster's API server.

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -83,17 +83,22 @@ func SetUserIdentificationFromRemoteSecretUser(config *rest.Config, user *Remote
 	}
 	exec := user.User.Exec
 	if exec != nil {
-		config.ExecProvider = &api.ExecConfig{
-			Command:            exec.Command,
-			Args:               exec.Args,
-			Env:                exec.Env,
-			APIVersion:         exec.APIVersion,
-			InstallHint:        cleanANSIEscapeCodes(exec.InstallHint),
-			ProvideClusterInfo: exec.ProvideClusterInfo,
-			InteractiveMode:    exec.InteractiveMode,
+		c := kialiConfig.Get()
+		if c.KialiFeatureFlags.Clustering.EnableExecProvider {
+			config.ExecProvider = &api.ExecConfig{
+				Command:            exec.Command,
+				Args:               exec.Args,
+				Env:                exec.Env,
+				APIVersion:         exec.APIVersion,
+				InstallHint:        cleanANSIEscapeCodes(exec.InstallHint),
+				ProvideClusterInfo: exec.ProvideClusterInfo,
+				InteractiveMode:    exec.InteractiveMode,
+			}
+			SetDefaultsExecConfig(config.ExecProvider)
+			log.Debugf("Auth ExecProvider has been detected: cmd=[%v], args=%v", exec.Command, exec.Args)
+		} else {
+			log.Warningf("Auth ExecProvider has been disabled. Connecting to remote clusters via an ExecProvider is prohibited.")
 		}
-		SetDefaultsExecConfig(config.ExecProvider)
-		log.Debugf("Auth ExecProvider has been detected: cmd=[%v], args=%v", exec.Command, exec.Args)
 	}
 }
 

--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -92,6 +92,8 @@ func SetUserIdentificationFromRemoteSecretUser(config *rest.Config, user *Remote
 			ProvideClusterInfo: exec.ProvideClusterInfo,
 			InteractiveMode:    exec.InteractiveMode,
 		}
+		SetDefaultsExecConfig(config.ExecProvider)
+		log.Debugf("Auth ExecProvider has been detected: cmd=[%v], args=%v", exec.Command, exec.Args)
 	}
 }
 

--- a/kubernetes/client_config.go
+++ b/kubernetes/client_config.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// cleanANSIEscapeCodes takes an arbitrary string and ensures that there are no
+// ANSI escape sequences that could put the terminal in a weird state (e.g.,
+// "\e[1m" bolds text)
+// From the "kubernetes/client-go" repository.
+// (https://github.com/kubernetes/client-go/blob/b8a8d9494492f5a03b3f1449bee19eb22fda4bd5/tools/clientcmd/client_config.go#L331)
+func cleanANSIEscapeCodes(s string) string {
+	// spaceControlCharacters includes tab, new line, vertical tab, new page, and
+	// carriage return. These are in the unicode.Cc category, but that category also
+	// contains ESC (U+001B) which we don't want.
+	spaceControlCharacters := unicode.RangeTable{
+		R16: []unicode.Range16{
+			{Lo: 0x0009, Hi: 0x000D, Stride: 1},
+		},
+	}
+
+	// Why not make this deny-only (instead of allow-only)? Because unicode.C
+	// contains newline and tab characters that we want.
+	allowedRanges := []*unicode.RangeTable{
+		unicode.L,
+		unicode.M,
+		unicode.N,
+		unicode.P,
+		unicode.S,
+		unicode.Z,
+		&spaceControlCharacters,
+	}
+	builder := strings.Builder{}
+	for _, roon := range s {
+		if unicode.IsOneOf(allowedRanges, roon) {
+			builder.WriteRune(roon) // returns nil error, per go doc
+		} else {
+			fmt.Fprintf(&builder, "%U", roon)
+		}
+	}
+	return builder.String()
+}

--- a/kubernetes/client_config.go
+++ b/kubernetes/client_config.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 // cleanANSIEscapeCodes takes an arbitrary string and ensures that there are no
@@ -57,4 +59,18 @@ func cleanANSIEscapeCodes(s string) string {
 		}
 	}
 	return builder.String()
+}
+
+// From the "kubernetes/client-go" repository.
+// (https://github.com/kubernetes/client-go/blob/b8a8d9494492f5a03b3f1449bee19eb22fda4bd5/tools/clientcmd/api/v1/defaults.go#L27-L37)
+func SetDefaultsExecConfig(exec *api.ExecConfig) {
+	if len(exec.InteractiveMode) == 0 {
+		switch exec.APIVersion {
+		case "client.authentication.k8s.io/v1beta1", "client.authentication.k8s.io/v1alpha1":
+			// default to IfAvailableExecInteractiveMode for backwards compatibility
+			exec.InteractiveMode = api.IfAvailableExecInteractiveMode
+		default:
+			// require other versions to explicitly declare whether they want stdin or not
+		}
+	}
 }

--- a/kubernetes/client_factory.go
+++ b/kubernetes/client_factory.go
@@ -212,7 +212,7 @@ func (cf *clientFactory) newClient(authInfo *api.AuthInfo, expirationTime time.D
 			} else {
 				remoteConfig, err2 = GetConfigWithTokenForRemoteCluster(clusterInfo[cluster].Cluster,
 					RemoteSecretUser{
-						Name: authInfo.Username, User: RemoteSecretUserToken{Token: authInfo.Token},
+						Name: authInfo.Username, User: RemoteSecretUserAuthInfo{Token: authInfo.Token},
 					})
 			}
 

--- a/kubernetes/client_test.go
+++ b/kubernetes/client_test.go
@@ -6,11 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kiali/kiali/config"
 )
 
 func TestSetUserIdentificationFromRemoteSecretUser(t *testing.T) {
 	assert := assert.New(t)
 
+	// by default, ExecProvider support should be disabled
 	cases := map[string]struct {
 		input    RemoteSecretUser
 		expected rest.Config
@@ -23,7 +26,62 @@ func TestSetUserIdentificationFromRemoteSecretUser(t *testing.T) {
 				},
 			},
 			expected: rest.Config{
-				BearerToken: "token",
+				BearerToken:  "token",
+				ExecProvider: nil,
+			},
+		},
+		"Use bearer token and exec credentials (which should be ignored)": {
+			input: RemoteSecretUser{
+				User: RemoteSecretUserAuthInfo{
+					Token: "token",
+					Exec: &RemoteSecretUserExec{
+						Command: "command",
+						Args:    []string{"arg1", "arg2"},
+						Env: []api.ExecEnvVar{
+							{Name: "ENV1", Value: "val1"},
+							{Name: "ENV2", Value: "val2"},
+						},
+						APIVersion:         "client.authentication.k8s.io/v1beta1",
+						InstallHint:        "hint",
+						ProvideClusterInfo: true,
+						InteractiveMode:    "IfAvailable",
+					},
+				},
+			},
+			expected: rest.Config{
+				BearerToken:  "token",
+				ExecProvider: nil,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			config := &rest.Config{}
+			SetUserIdentificationFromRemoteSecretUser(config, &tc.input)
+			assert.Equal(tc.expected, *config)
+		})
+	}
+
+	// now enable ExecProvider support
+	conf := config.NewConfig()
+	conf.KialiFeatureFlags.Clustering.EnableExecProvider = true
+	config.Set(conf)
+
+	cases = map[string]struct {
+		input    RemoteSecretUser
+		expected rest.Config
+	}{
+		"Only bearer token": {
+			input: RemoteSecretUser{
+				User: RemoteSecretUserAuthInfo{
+					Token: "token",
+					Exec:  nil,
+				},
+			},
+			expected: rest.Config{
+				BearerToken:  "token",
+				ExecProvider: nil,
 			},
 		},
 		"Use bearer token and exec credentials": {

--- a/kubernetes/client_test.go
+++ b/kubernetes/client_test.go
@@ -1,0 +1,72 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestSetUserIdentificationFromRemoteSecretUser(t *testing.T) {
+	assert := assert.New(t)
+
+	cases := map[string]struct {
+		input    RemoteSecretUser
+		expected rest.Config
+	}{
+		"Only bearer token": {
+			input: RemoteSecretUser{
+				User: RemoteSecretUserAuthInfo{
+					Token: "token",
+					Exec:  nil,
+				},
+			},
+			expected: rest.Config{
+				BearerToken: "token",
+			},
+		},
+		"Use bearer token and exec credentials": {
+			input: RemoteSecretUser{
+				User: RemoteSecretUserAuthInfo{
+					Token: "token",
+					Exec: &RemoteSecretUserExec{
+						Command: "command",
+						Args:    []string{"arg1", "arg2"},
+						Env: []api.ExecEnvVar{
+							{Name: "ENV1", Value: "val1"},
+							{Name: "ENV2", Value: "val2"},
+						},
+						APIVersion:         "client.authentication.k8s.io/v1beta1",
+						InstallHint:        "hint",
+						ProvideClusterInfo: true,
+						InteractiveMode:    "IfAvailable",
+					},
+				},
+			},
+			expected: rest.Config{
+				BearerToken: "token",
+				ExecProvider: &api.ExecConfig{
+					Command: "command",
+					Args:    []string{"arg1", "arg2"},
+					Env: []api.ExecEnvVar{
+						{Name: "ENV1", Value: "val1"},
+						{Name: "ENV2", Value: "val2"},
+					},
+					APIVersion:         "client.authentication.k8s.io/v1beta1",
+					InstallHint:        "hint",
+					ProvideClusterInfo: true,
+					InteractiveMode:    "IfAvailable",
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			config := &rest.Config{}
+			SetUserIdentificationFromRemoteSecretUser(config, &tc.input)
+			assert.Equal(tc.expected, *config)
+		})
+	}
+}

--- a/kubernetes/cluster_secret_test.go
+++ b/kubernetes/cluster_secret_test.go
@@ -43,7 +43,7 @@ func TestReloadRemoteClusterSecret(t *testing.T) {
 		Users: []RemoteSecretUser{
 			{
 				Name: "remoteuser1",
-				User: RemoteSecretUserToken{
+				User: RemoteSecretUserAuthInfo{
 					Token: "remotetoken1",
 				},
 			},

--- a/kubernetes/secret.go
+++ b/kubernetes/secret.go
@@ -5,6 +5,7 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 	core_v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 type RemoteSecretCluster struct {
@@ -18,12 +19,23 @@ type RemoteSecretClusterListItem struct {
 }
 
 type RemoteSecretUser struct {
-	Name string                `yaml:"name"`
-	User RemoteSecretUserToken `yaml:"user"`
+	Name string                   `yaml:"name"`
+	User RemoteSecretUserAuthInfo `yaml:"user"`
 }
 
-type RemoteSecretUserToken struct {
-	Token string `yaml:"token"`
+type RemoteSecretUserAuthInfo struct {
+	Token string                `yaml:"token"`
+	Exec  *RemoteSecretUserExec `yaml:"exec"`
+}
+
+type RemoteSecretUserExec struct {
+	Command            string                  `yaml:"command"`
+	Args               []string                `yaml:"args"`
+	Env                []api.ExecEnvVar        `yaml:"env"`
+	APIVersion         string                  `yaml:"apiVersion"`
+	InstallHint        string                  `yaml:"installHint"`
+	ProvideClusterInfo bool                    `yaml:"provideClusterInfo"`
+	InteractiveMode    api.ExecInteractiveMode `yaml:"interactiveMode"`
 }
 
 // RemoteSecret contains all the content for a secret containing kubeconfig information.


### PR DESCRIPTION
@frauniki This is a PR to your kiali exec provider PR ...

You are not rebased on the lastest master which is why I think  this PR shows so many commits. But the commit this PR introduces is this one:

https://github.com/frauniki/kiali/commit/79ea6d94ce19d56a17c0c23835987050a3753c6b

This adds a flag that can be used to turn on the execprovider feature (by default it is off).